### PR TITLE
Create firewall-sim.py

### DIFF
--- a/backend/scripts/security/firewall-sim.py
+++ b/backend/scripts/security/firewall-sim.py
@@ -1,0 +1,23 @@
+import random
+def generate_ip():
+  return f"192.168.1.{random.randint(0,20)}"
+def check_firewall_action(ip,rules):
+  for ip_rule,action in rules.items():
+    if ip == ip_rule:
+      return action
+  return "ALLOW!!"
+def main():
+  firewall_rules={
+      "192.168.1.1":"Block",
+      "192.168.1.15":"Block",
+      "192.168.1.2":"Block",
+      "192.168.1.5":"Block",
+      "192.168.1.10":"Block",
+      "192.168.1.7":"Block",
+}
+  for i in range(12):
+    ip_adress=generate_ip()
+    act=check_firewall_action(ip_adress,firewall_rules)
+    print(f"IP:{ip_adress},Action:{act}")
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
Description

This PR adds a Python program that simulates a basic firewall by generating random IP addresses within the range 192.168.1.0–192.168.1.20 and checking them against predefined firewall rules. The program decides whether to Block or Allow each IP request.

 Features

generate_ip() → Generates random IPs.

check_firewall_action(ip, rules) → Checks IP against firewall rules and returns action.

Predefined rules to block specific IPs (192.168.1.1, 192.168.1.2, 192.168.1.5, 192.168.1.7, 192.168.1.10, 192.168.1.15).

Simulates 12 random IP requests and prints action results

Sample output

`IP:192.168.1.7, Action:Block
IP:192.168.1.12, Action:ALLOW!!
IP:192.168.1.1, Action:Block`

How to run 
`python firewall_simulation.py`

Use Cases

Demonstrates how firewall rules work in a simple environment.

Can be extended to block ranges, log traffic, or implement more complex rule matching.

Closes issue no.
#31 
